### PR TITLE
feat: add optional component labels to board definitions

### DIFF
--- a/src/composables/use-component-label.ts
+++ b/src/composables/use-component-label.ts
@@ -1,0 +1,34 @@
+import { Block } from "../definitions/interface";
+import { deviceStore } from "../store";
+import { getBoardDefinition } from "../definitions/board";
+
+export const getComponentLabel = (block: Block, index: number): string => {
+  const board = getBoardDefinition(deviceStore.state.boardId);
+  if (!board?.componentLabels) {
+    return String(index);
+  }
+
+  let labels: string[] | undefined;
+  switch (block) {
+    case Block.Switch:
+      labels = board.componentLabels.switches;
+      break;
+    case Block.Encoder:
+      labels = board.componentLabels.encoders;
+      break;
+    case Block.Analog:
+      labels = board.componentLabels.analogs;
+      break;
+    case Block.Output:
+      labels = board.componentLabels.outputs;
+      break;
+    case Block.Display:
+      labels = board.componentLabels.i2c;
+      break;
+    case Block.Touchscreen:
+      labels = board.componentLabels.touchscreen;
+      break;
+  }
+
+  return labels?.[index] ?? String(index);
+};

--- a/src/definitions/device/DeviceForm.vue
+++ b/src/definitions/device/DeviceForm.vue
@@ -9,7 +9,7 @@
         <div class="mr-6 text-foreground">
           {{ blockDefinition.title }}
           <strong>
-            {{ index }}
+            {{ componentLabel }}
           </strong>
         </div>
         <div class="hidden md:block md:flex-grow text-right">
@@ -61,6 +61,7 @@ import { SectionType, Block, ISectionDefinition } from "../../definitions";
 import { deviceStoreMapped } from "../../store";
 import router from "../../router";
 import { useDeviceForm } from "../../composables";
+import { getComponentLabel } from "../../composables/use-component-label";
 
 interface ISectionGroup {
   key: string;
@@ -112,6 +113,7 @@ export default defineComponent({
       outputId,
       numberOfComponents,
       index,
+      componentLabel: computed(() => getComponentLabel(props.block, index.value)),
       ...form,
       sectionGroups,
     };

--- a/src/definitions/device/DeviceGrid.vue
+++ b/src/definitions/device/DeviceGrid.vue
@@ -70,6 +70,7 @@
           v-for="index in indexRange"
           :key="`table-form-${index}`"
           :index="index"
+          :label="getComponentLabel(block, index)"
           :form-data="columnViewData[index]"
           :show-field="showField"
           :sections="sections"
@@ -87,7 +88,7 @@
         :index="index - 1"
         :highlight="highlights[block][index - 1]"
       >
-        <span class="text-xl font-bold">{{ index - 1 }}</span>
+        <span class="text-xl font-bold">{{ getComponentLabel(block, index - 1) }}</span>
       </DeviceGridButton>
     </div>
     <template v-else-if="segments && segments.length">
@@ -111,7 +112,7 @@
             :index="index"
             :highlight="highlights[block][index]"
           >
-            <span class="text-xl font-bold">{{ index }}</span>
+            <span class="text-xl font-bold">{{ getComponentLabel(block, index) }}</span>
           </DeviceGridButton>
         </div>
       </div>
@@ -128,6 +129,7 @@ import {
   useViewSettings,
   useGridSegments,
 } from "../../composables";
+import { getComponentLabel } from "../../composables/use-component-label";
 import DeviceGridButton from "./DeviceGridButton.vue";
 import DeviceTableComponentRow from "./DeviceTableComponentRow.vue";
 
@@ -200,6 +202,7 @@ export default defineComponent({
       sections,
       showMsbControls,
       segments,
+      getComponentLabel,
     };
   },
 });

--- a/src/definitions/device/DeviceTableComponentRow.vue
+++ b/src/definitions/device/DeviceTableComponentRow.vue
@@ -7,7 +7,7 @@
           'btn-highlight': isHighlighted,
         }"
       >
-        {{ index }}
+        {{ label || index }}
       </span>
     </div>
     <template v-for="section in sections">
@@ -45,6 +45,10 @@ export default defineComponent({
     index: {
       required: true,
       type: Number,
+    },
+    label: {
+      default: "",
+      type: String,
     },
     sections: {
       required: true,

--- a/src/definitions/interface.ts
+++ b/src/definitions/interface.ts
@@ -267,6 +267,14 @@ export interface IBoardDefinition {
   name: string;
   ids: number[][];
   firmwareFileName?: string;
+  componentLabels?: {
+    switches?: string[];
+    encoders?: string[];
+    analogs?: string[];
+    outputs?: string[];
+    i2c?: string[];
+    touchscreen?: string[];
+  };
 }
 
 export enum RequestState {


### PR DESCRIPTION
Hi! First of all, thank you so much for OpenDeck — it's an incredible platform and the quality of the protocol documentation and UI are outstanding. We're building a custom MIDI controller on top of OpenDeck and it's been a joy to work with.

## What this PR does

This adds an optional `componentLabels` field to `IBoardDefinition`, allowing custom boards to define human-readable names for their indexed components.

For example, a board with physically labeled buttons (A–F) and named encoders (Vol, Gain) can now show those labels in the grid, table, and form views instead of numeric indices.

## Why

When building custom enclosures, the physical hardware often has labels that don't match the numeric indices (e.g., buttons labeled A–F rather than 0–5). This small addition makes the configurator feel native to custom boards without changing behavior for boards that don't define labels.

## Example usage

```ts
{
  name: "My Custom Board",
  ids: [[1, 2, 3, 4]],
  componentLabels: {
    switches: ["A", "B", "C", "D", "E", "F"],
    encoders: ["Vol", "Gain"],
    analogs: ["Exp 1", "Exp 2"],
    outputs: ["Ring 1", "Ring 2", "Status"],
  },
}
```

## Limitation / open question

Currently, adding labels requires modifying `boards.ts` in the source — meaning custom boards still need to fork the UI. A future improvement could be to support loading board definitions from an external source (e.g., a JSON file served alongside the UI, or even reported by the board itself via SysEx). Happy to explore that direction if there's interest.

## Details

- Adds optional `componentLabels?` to `IBoardDefinition` (switches, encoders, analogs, outputs, i2c, touchscreen)
- Adds a small composable (`use-component-label.ts`) that resolves labels by block + index
- Updates `DeviceGrid.vue`, `DeviceTableComponentRow.vue`, and `DeviceForm.vue` to use labels when available
- Falls back to the existing numeric display when no labels are defined
- Fully backwards compatible — no existing behavior changes

## Testing

- `yarn build` passes cleanly
- Tested with a custom board definition; labels display correctly in grid, table, and individual component views

Thank you for considering this! Happy to adjust anything based on your feedback.